### PR TITLE
[#31][#32] 팀 리스트 반환, 경기 리스트 반환 api 구현

### DIFF
--- a/be/src/main/java/com/codesquad/team3/baseball/controller/MainController.java
+++ b/be/src/main/java/com/codesquad/team3/baseball/controller/MainController.java
@@ -1,23 +1,34 @@
 package com.codesquad.team3.baseball.controller;
 
+import com.codesquad.team3.baseball.dao.MainDAO;
 import com.codesquad.team3.baseball.dto.ResponseData;
 import com.codesquad.team3.baseball.dto.Status;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
+
 @RestController
 @RequestMapping("/api")
 public class MainController {
 
+    private MainDAO mainDAO;
+
+    public MainController(MainDAO mainDAO) {
+        this.mainDAO = mainDAO;
+    }
+
     @GetMapping("/teams")
     public ResponseEntity<ResponseData> getTeams() {
-        return new ResponseEntity<>(new ResponseData(Status.SUCCESS, null), HttpStatus.OK);
+        HashMap<String, Object> teams = new HashMap<>();
+        teams.put("teams", mainDAO.selectAllTeams());
+        return new ResponseEntity<>(new ResponseData(Status.SUCCESS, teams), HttpStatus.OK);
     }
 
     @GetMapping("/games")
-    public ResponseEntity<ResponseData> getGames() {
-        return new ResponseEntity<>(new ResponseData(Status.SUCCESS, null), HttpStatus.OK);
+    public ResponseEntity<ResponseData> getTeamGames() {
+        return new ResponseEntity<>(new ResponseData(Status.SUCCESS, mainDAO.selectAllTeamGames()), HttpStatus.OK);
     }
 
     @PatchMapping("/games/{gameId}/teams/{teamId}")

--- a/be/src/main/java/com/codesquad/team3/baseball/controller/MatchingController.java
+++ b/be/src/main/java/com/codesquad/team3/baseball/controller/MatchingController.java
@@ -1,8 +1,8 @@
 package com.codesquad.team3.baseball.controller;
 
-import com.codesquad.team3.baseball.dao.MainDAO;
 import com.codesquad.team3.baseball.dto.ResponseData;
 import com.codesquad.team3.baseball.dto.Status;
+import com.codesquad.team3.baseball.service.MatchingService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,24 +11,25 @@ import java.util.HashMap;
 
 @RestController
 @RequestMapping("/api")
-public class MainController {
+public class MatchingController {
 
-    private MainDAO mainDAO;
+    private MatchingService matchingService;
 
-    public MainController(MainDAO mainDAO) {
-        this.mainDAO = mainDAO;
+    public MatchingController(MatchingService matchingService) {
+        this.matchingService = matchingService;
     }
 
     @GetMapping("/teams")
     public ResponseEntity<ResponseData> getTeams() {
         HashMap<String, Object> teams = new HashMap<>();
-        teams.put("teams", mainDAO.selectAllTeams());
+        teams.put("teams", matchingService.getAllTeams());
         return new ResponseEntity<>(new ResponseData(Status.SUCCESS, teams), HttpStatus.OK);
     }
 
     @GetMapping("/games")
-    public ResponseEntity<ResponseData> getTeamGames() {
-        return new ResponseEntity<>(new ResponseData(Status.SUCCESS, mainDAO.selectAllTeamGames()), HttpStatus.OK);
+    public ResponseEntity<ResponseData> getGames() {
+
+        return new ResponseEntity<>(new ResponseData(Status.SUCCESS, matchingService.getAllGames()), HttpStatus.OK);
     }
 
     @PatchMapping("/games/{gameId}/teams/{teamId}")

--- a/be/src/main/java/com/codesquad/team3/baseball/controller/MatchingController.java
+++ b/be/src/main/java/com/codesquad/team3/baseball/controller/MatchingController.java
@@ -21,9 +21,7 @@ public class MatchingController {
 
     @GetMapping("/teams")
     public ResponseEntity<ResponseData> getTeams() {
-        HashMap<String, Object> teams = new HashMap<>();
-        teams.put("teams", matchingService.getAllTeams());
-        return new ResponseEntity<>(new ResponseData(Status.SUCCESS, teams), HttpStatus.OK);
+        return new ResponseEntity<>(new ResponseData(Status.SUCCESS, matchingService.getAllTeams()), HttpStatus.OK);
     }
 
     @GetMapping("/games")

--- a/be/src/main/java/com/codesquad/team3/baseball/controller/MatchingController.java
+++ b/be/src/main/java/com/codesquad/team3/baseball/controller/MatchingController.java
@@ -7,8 +7,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
-
 @RestController
 @RequestMapping("/api")
 public class MatchingController {

--- a/be/src/main/java/com/codesquad/team3/baseball/dao/MainDAO.java
+++ b/be/src/main/java/com/codesquad/team3/baseball/dao/MainDAO.java
@@ -1,16 +1,58 @@
 package com.codesquad.team3.baseball.dao;
 
+import com.codesquad.team3.baseball.dto.GameDTO;
+import com.codesquad.team3.baseball.dto.TeamDTO;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.List;
 
+@Repository
 public class MainDAO {
 
-    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
     @Autowired
     public MainDAO(DataSource dataSource) {
-        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    public List<TeamDTO> selectAllTeams() {
+        String sql = "SELECT name, url, color FROM team";
+        return jdbcTemplate.query(sql, (rs, rowNum) -> {
+            TeamDTO.Builder builder = new TeamDTO.Builder(rs.getString("name"))
+                    .url(rs.getString("url"))
+                    .color(rs.getString("color"));
+            return new TeamDTO(builder);
+        });
+    }
+
+    public List<GameDTO> selectAllTeamGames() {
+        String sql = "SELECT h.game AS game_id," +
+                " h.id AS home_id, h.name AS home_name, h.thumbnail_url AS home_thumbnail_url," +
+                " a.id AS away_id, a.name AS away_name, a.thumbnail_url AS away_thumbnail_url" +
+                " FROM" +
+                " (SELECT tg.game AS game, t.id, t.name, t.thumbnail_url" +
+                    " FROM team t, team_game tg" +
+                    " WHERE t.id = tg.team AND tg.is_home = true) AS h" +
+                " LEFT OUTER JOIN" +
+                " (SELECT tg.game AS game, t.id, t.name, t.thumbnail_url" +
+                    " FROM team t, team_game tg" +
+                    " WHERE t.id = tg.team AND tg.is_home = false) AS a" +
+                " ON h.game = a.game," +
+                " game g" +
+                " WHERE g.id = h.game" +
+                " AND g.is_over = false";
+        return jdbcTemplate.query(sql, (rs, rowNum) -> {
+            TeamDTO.Builder home = new TeamDTO.Builder(rs.getString("home_name"))
+                    .id(rs.getInt("home_id"))
+                    .thumbnailUrl(rs.getString("home_thumbnail_url"));
+            TeamDTO.Builder away = new TeamDTO.Builder(rs.getString("away_name"))
+                    .id(rs.getInt("away_id"))
+                    .thumbnailUrl(rs.getString("away_thumbnail_url"));
+            return new GameDTO(rs.getInt("game_id"), home.build(), away.build());
+        });
     }
 }

--- a/be/src/main/java/com/codesquad/team3/baseball/dao/MatchingDAO.java
+++ b/be/src/main/java/com/codesquad/team3/baseball/dao/MatchingDAO.java
@@ -10,12 +10,12 @@ import javax.sql.DataSource;
 import java.util.List;
 
 @Repository
-public class MainDAO {
+public class MatchingDAO {
 
     private JdbcTemplate jdbcTemplate;
 
     @Autowired
-    public MainDAO(DataSource dataSource) {
+    public MatchingDAO(DataSource dataSource) {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 

--- a/be/src/main/java/com/codesquad/team3/baseball/service/MatchingService.java
+++ b/be/src/main/java/com/codesquad/team3/baseball/service/MatchingService.java
@@ -1,0 +1,26 @@
+package com.codesquad.team3.baseball.service;
+
+import com.codesquad.team3.baseball.dao.MatchingDAO;
+import com.codesquad.team3.baseball.dto.GameDTO;
+import com.codesquad.team3.baseball.dto.TeamDTO;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MatchingService {
+
+    private MatchingDAO matchingDAO;
+
+    public MatchingService(MatchingDAO matchingDAO) {
+        this.matchingDAO = matchingDAO;
+    }
+
+    public List<TeamDTO> getAllTeams() {
+        return matchingDAO.selectAllTeams();
+    }
+
+    public List<GameDTO> getAllGames() {
+        return matchingDAO.selectAllTeamGames();
+    }
+}

--- a/be/src/main/java/com/codesquad/team3/baseball/service/MatchingService.java
+++ b/be/src/main/java/com/codesquad/team3/baseball/service/MatchingService.java
@@ -5,7 +5,9 @@ import com.codesquad.team3.baseball.dto.GameDTO;
 import com.codesquad.team3.baseball.dto.TeamDTO;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class MatchingService {
@@ -16,8 +18,10 @@ public class MatchingService {
         this.matchingDAO = matchingDAO;
     }
 
-    public List<TeamDTO> getAllTeams() {
-        return matchingDAO.selectAllTeams();
+    public Map<String, List<TeamDTO>> getAllTeams() {
+        HashMap<String, List<TeamDTO>> teams = new HashMap<>();
+        teams.put("teams", matchingDAO.selectAllTeams());
+        return teams;
     }
 
     public List<GameDTO> getAllGames() {

--- a/be/src/main/resources/data.sql
+++ b/be/src/main/resources/data.sql
@@ -61,3 +61,6 @@ VALUES (1, 1, 1, true), (2, 1, 2, false),
         (5, 3, null, true), (6, 3, null, false),
         (7, 4, 3, true), (8, 4, null, false),
         (9, 5, null, true), (10, 5, null, false);
+
+INSERT INTO game_manager (is_updated)
+VALUES ( FALSE );

--- a/be/src/main/resources/data.sql
+++ b/be/src/main/resources/data.sql
@@ -52,7 +52,7 @@ INSERT INTO game (id, home_batting_order, away_batting_order, is_over)
 VALUES (1, 1, 1, false),
         (2, 1, 1, false),
         (3, 1, 1, false),
-        (4, 1, 1, true),
+        (4, 1, 1, false),
         (5, 1, 1, false);
 
 INSERT INTO team_game (team, game, user, is_home)

--- a/be/src/main/resources/data.sql
+++ b/be/src/main/resources/data.sql
@@ -48,12 +48,12 @@ VALUES ('정수빈', false, 0.211, 1, 1), ('오재원', false, 0.237, 2, 1), ('�
         ('노수광', false, 0.250, 1, 10), ('고종욱', false, 0.323, 2, 10), ('최정', false, 0.292, 3, 10), ('로맥', false, 0.276, 4, 10), ('한동민', false, 0.265, 5, 10),
         ('나주환', false, 0.222, 6, 10), ('이재원', false, 0.268, 7, 10), ('김창평', false, 0.178, 8, 10), ('정현', false, 0.246, 9, 10), ('킹엄', true, -1, -1, 10);
 
-INSERT INTO game (id, home_batting_order, away_batting_order)
-VALUES (1, 1, 1),
-        (2, 1, 1),
-        (3, 1, 1),
-        (4, 1, 1),
-        (5, 1, 1);
+INSERT INTO game (id, home_batting_order, away_batting_order, is_over)
+VALUES (1, 1, 1, false),
+        (2, 1, 1, false),
+        (3, 1, 1, false),
+        (4, 1, 1, true),
+        (5, 1, 1, false);
 
 INSERT INTO team_game (team, game, user, is_home)
 VALUES (1, 1, 1, true), (2, 1, 2, false),

--- a/be/src/main/resources/schema.sql
+++ b/be/src/main/resources/schema.sql
@@ -39,7 +39,7 @@ CREATE TABLE game (
     id INT AUTO_INCREMENT PRIMARY KEY ,
     home_batting_order INT NOT NULL ,
     away_batting_order INT NOT NULL ,
-    is_over BOOLEAN DEFAULT FALSE
+    is_over BOOLEAN DEFAULT FALSE NOT NULL
 );
 
 CREATE TABLE team_game (


### PR DESCRIPTION
Closed #31 #32 

- 경기 리스트 반환 시, game의 is_over 컬럼이 false인 경우만 반환하도록 구현했습니다.
- 경기 리스트 반환 시, 서브 쿼리를 이용하여 `LEFT JOIN`한 이유는 하나의 행에 home과 away를 `select` 해오기 위함입니다.

## 공부할 것
- `where` 절로 참조키를 매칭하는 것과 `LEFT JOIN`의 차이점

  > 예시
  ```
  SELECT * FROM A a, B b WHERE a.b = b.a;
  SELECT * FROM A LEFT OUTER JOIN B b ON a.b = b.a;
  ```
## 고민해봐야 할 점
  - 경기가 종료되지 않았지만 시작된 경기 리스트도 보여줘야 할지? 보여주도 별도로 표시해줘야할지?
  - 경기가 시작된 것을 나타내는 컬럼도 필요할 것으로 예상됩니다.